### PR TITLE
No Jester and Necromancer

### DIFF
--- a/lua/terrortown/entities/roles/necromancer/shared.lua
+++ b/lua/terrortown/entities/roles/necromancer/shared.lua
@@ -113,4 +113,15 @@ if SERVER then
 			selectableRoles[JACKAL] = nil
 		end
 	end)
+	
+	-- make sure that jester and necro can not spawn together
+	hook.Add("TTT2ModifySelectableRoles", "TTTHJestOrNecro", function(selectableRoles)
+		if not selectableRoles[NECROMANCER] or not selectableRoles[JESTER] then return end
+
+		if math.random(2) == 2 then
+			selectableRoles[NECROMANCER] = nil
+		else
+			selectableRoles[JESTER] = nil
+		end
+	end)
 end


### PR DESCRIPTION
This change makes it so the Necromancer can't spawn in a round with the Jester.
Rounds with both of these roles are very awkward, as the zombies and necromancer must be careful to not kill the jester, which is sometimes impossible.
I've tested this a little bit and everything seems to be working fine.