### PR TITLE
Fixed edge-case issue where Necromancer could revive alive player

### DIFF
--- a/lua/terrortown/lang/de/necromancer.lua
+++ b/lua/terrortown/lang/de/necromancer.lua
@@ -34,6 +34,7 @@ L["necrodefi_error_no_valid_ply"] = "Du kannst diesen Spieler nicht wiederbelebe
 L["necrodefi_error_already_reviving"] = "Du kannst diesen Spieler nicht wiederbeleben, da er bereits wiederbelebt wird."
 L["necrodefi_error_failed"] = "Wiederbeleben fehlgeschlagen. Bitte versuche es erneut."
 L["necrodefi_error_zombie"] = "Du kannst kein Zombie wiederbeleben."
+-- L["necrodefi_error_player_alive"] = "You can't revive this player, they are already alive."
 
 L["tooltip_necro_revive_score"] = "Geisterbeschwörung: {score}"
 L["necro_revive_score"] = "Geisterbeschwörung:"

--- a/lua/terrortown/lang/en/necromancer.lua
+++ b/lua/terrortown/lang/en/necromancer.lua
@@ -34,6 +34,7 @@ L["necrodefi_error_no_valid_ply"] = "You can't revive this player since they are
 L["necrodefi_error_already_reviving"] = "You can't revive this player since they are already reviving."
 L["necrodefi_error_failed"] = "Revival attempt failed. Please try again."
 L["necrodefi_error_zombie"] = "You can't revive a zombie."
+L["necrodefi_error_player_alive"] = "You can't revive this player, they are already alive."
 
 L["tooltip_necro_revive_score"] = "Necro revival: {score}"
 L["necro_revive_score"] = "Necro Revival:"

--- a/lua/terrortown/lang/es/necromancer.lua
+++ b/lua/terrortown/lang/es/necromancer.lua
@@ -34,6 +34,7 @@ L["necrodefi_error_no_valid_ply"] = "No puedes revivir a este jugador ya que su 
 L["necrodefi_error_already_reviving"] = "No puedes revivir a este jugador porque ya lo están reviviendo."
 L["necrodefi_error_failed"] = "Intento de revivir fallido. Intenta de nuevo."
 L["necrodefi_error_zombie"] = "No puedes revivir a un Zombie."
+-- L["necrodefi_error_player_alive"] = "You can't revive this player, they are already alive."
 
 --L["tooltip_necro_revive_score"] = "Necro revival: {score}"
 --L["necro_revive_score"] = "Necro Revival:"

--- a/lua/terrortown/lang/fr/necromancer.lua
+++ b/lua/terrortown/lang/fr/necromancer.lua
@@ -34,6 +34,7 @@ L["necrodefi_error_no_valid_ply"] = "Vous ne pouvez pas réanimer ce joueur car 
 L["necrodefi_error_already_reviving"] = "Vous ne pouvez pas réanimer ce joueur parce qu'il est déjà réanimé."
 L["necrodefi_error_failed"] = "La tentative de réanimation a échoué. Veuillez réessayer."
 L["necrodefi_error_zombie"] = "Vous ne pouvez pas faire revivre un zombie."
+-- L["necrodefi_error_player_alive"] = "You can't revive this player, they are already alive."
 
 --L["tooltip_necro_revive_score"] = "Necro revival: {score}"
 --L["necro_revive_score"] = "Necro Revival:"

--- a/lua/terrortown/lang/it/necromancer.lua
+++ b/lua/terrortown/lang/it/necromancer.lua
@@ -34,6 +34,7 @@ L["necrodefi_error_no_valid_ply"] = "Non puoi rianimare questo giocatore perchè
 L["necrodefi_error_already_reviving"] = "Non puoi rianimare questo giocatore perchè è gia stato rianimato."
 L["necrodefi_error_failed"] = "Tentativo di rianimazione fallito. Riprova."
 L["necrodefi_error_zombie"] = "Non puoi rianimare uno Zombie."
+-- L["necrodefi_error_player_alive"] = "You can't revive this player, they are already alive."
 
 --L["tooltip_necro_revive_score"] = "Necro revival: {score}"
 --L["necro_revive_score"] = "Necro Revival:"

--- a/lua/terrortown/lang/ru/necromancer.lua
+++ b/lua/terrortown/lang/ru/necromancer.lua
@@ -34,6 +34,7 @@ L["necrodefi_error_no_valid_ply"] = "Вы не можете оживить эт�
 L["necrodefi_error_already_reviving"] = "Вы не можете оживить этого игрока, так как он уже оживает."
 L["necrodefi_error_failed"] = "Попытка возрождения не удалась. Пожалуйста, попробуйте ещё раз."
 L["necrodefi_error_zombie"] = "Вы не можете оживить зомби."
+-- L["necrodefi_error_player_alive"] = "You can't revive this player, they are already alive."
 
 --L["tooltip_necro_revive_score"] = "Necro revival: {score}"
 --L["necro_revive_score"] = "Necro Revival:"


### PR DESCRIPTION
If, somehow, an Alive player had a valid corpse on the map (such as because of the Death Faker traitor weapon), the Necromancer could "revive" the corpse, teleporting the player and changing their role.

This update fixes that issue, adding a `player:Alive()` check and a new error message if the targeted corpse's player is actually alive (this error may kind of ruin the Death Faker conceptually, but I'm not sure of a better solution). 