### PR TITLE
fixed defi drop

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
@@ -37,6 +37,10 @@ SWEP.cvars = {
 SWEP.revivalReason = "revived_by_necromancer"
 
 if SERVER then
+    function SWEP:OnDrop()
+        self:Remove()
+    end
+
     function SWEP:OnRevive(ply, owner)
         AddZombie(ply, owner)
     end


### PR DESCRIPTION
Due to the recent changes the Necromancer defibrillator is now being dropped if he dies. 
OnDrop was removed from the Necromancer defibrillator but in the original defibrillator the OnDrop doesn't remove the defibrillator.
This PR fixes this issue.