### PR TITLE
fixed typo

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
@@ -51,7 +51,7 @@ if SERVER then
         AddZombie(ply, owner)
     end
 
-    function SWEP:OnReviveStart(ply, owener)
+    function SWEP:OnReviveStart(ply, owner)
         if not cvReviveZombies:GetBool() and ply:GetSubRole() == ROLE_ZOMBIE then
             LANG.Msg(owner, "necrodefi_error_zombie", nil, MSG_MSTACK_WARN)
 


### PR DESCRIPTION
Fixed a typo which caused some issues if someone tried to revive a Zombie again with the Necromancer defibrillator. Everyone saw the error popup. This should be fixed now.