### PR TITLE
Fixed revival cancelation

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
@@ -44,7 +44,7 @@ SWEP.revivalReason = "revived_by_necromancer"
 
 if SERVER then
     function SWEP:OnDrop()
-        self:CancelRevival(self.defiPly)
+        BaseClass.OnDrop(self)
         self:Remove()
     end
 
@@ -53,7 +53,6 @@ if SERVER then
     end
 
     function SWEP:OnReviveStart(ply, owner)
-        self.defiPly = ply
         if not cvReviveZombies:GetBool() and ply:GetSubRole() == ROLE_ZOMBIE then
             LANG.Msg(owner, "necrodefi_error_zombie", nil, MSG_MSTACK_WARN)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
@@ -44,6 +44,7 @@ SWEP.revivalReason = "revived_by_necromancer"
 
 if SERVER then
     function SWEP:OnDrop()
+        self:CancelRevival(self.defiPly)
         self:Remove()
     end
 
@@ -52,6 +53,7 @@ if SERVER then
     end
 
     function SWEP:OnReviveStart(ply, owner)
+        self.defiPly = ply
         if not cvReviveZombies:GetBool() and ply:GetSubRole() == ROLE_ZOMBIE then
             LANG.Msg(owner, "necrodefi_error_zombie", nil, MSG_MSTACK_WARN)
 


### PR DESCRIPTION
I noticed an issue with the revival cancelation with the Necromancer Defibrillator and also with the Medic Defibrillator while working on https://github.com/TTT-2/ttt2-wep_defi/pull/25 .

If for example the Necromancer dies while reviving someone the person still gets revived.
The revival is never cancelled.
It also happens for the Medic.

Both use the Defibrillator as a base and it works fine for the Defibrillator because the cancelation happens in `OnDrop`.
I call the `OnDrop` method from the base (Defibrillator) in the Necromancer and it worked fine during my tests.