### PR TITLE
Fixed defi loadout issue

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttth_necrodefi.lua
@@ -18,7 +18,7 @@ if CLIENT then
     SWEP.Icon = "vgui/ttt/icon_defi_necro"
 end
 
-SWEP.Kind = WEAPON_EQUIP2
+SWEP.Kind = WEAPON_ROLE
 SWEP.CanBuy = nil
 SWEP.notBuyable = true
 


### PR DESCRIPTION
This PR fixes a loadout issue with the Necromancer Defibrillator.
If a player, who will become Necromancer, has something at slot 7 (`WEAPON_EQUIP2`) before everyone gets his role then he doesn't receive his Defibrillator.

By changing it to slot 8 (`WEAPON_ROLE`) it will work, even if he has already multiple items at slot 8.
I tested it and confirmed that it works (had two items at slot 8 and still got the Defibrillator).